### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_shogun/_formats.py
+++ b/q2_shogun/_formats.py
@@ -20,12 +20,12 @@ class Bowtie2IndexFileFormat(model.BinaryFileFormat):
 
 
 class Bowtie2IndexDirFmt(model.DirectoryFormat):
-    idx1 = model.File('.+(?<!\.rev)\.1\.bt2', format=Bowtie2IndexFileFormat)
-    idx2 = model.File('.+(?<!\.rev)\.2\.bt2', format=Bowtie2IndexFileFormat)
-    ref3 = model.File('.+\.3\.bt2', format=Bowtie2IndexFileFormat)
-    ref4 = model.File('.+\.4\.bt2', format=Bowtie2IndexFileFormat)
-    rev1 = model.File('.+\.rev\.1\.bt2', format=Bowtie2IndexFileFormat)
-    rev2 = model.File('.+\.rev\.2\.bt2', format=Bowtie2IndexFileFormat)
+    idx1 = model.File(r'.+(?<!\.rev)\.1\.bt2', format=Bowtie2IndexFileFormat)
+    idx2 = model.File(r'.+(?<!\.rev)\.2\.bt2', format=Bowtie2IndexFileFormat)
+    ref3 = model.File(r'.+\.3\.bt2', format=Bowtie2IndexFileFormat)
+    ref4 = model.File(r'.+\.4\.bt2', format=Bowtie2IndexFileFormat)
+    rev1 = model.File(r'.+\.rev\.1\.bt2', format=Bowtie2IndexFileFormat)
+    rev2 = model.File(r'.+\.rev\.2\.bt2', format=Bowtie2IndexFileFormat)
 
     def get_name(self):
         filename = str(self.idx1.path_maker().relative_to(self.path))

--- a/q2_shogun/_shogun.py
+++ b/q2_shogun/_shogun.py
@@ -58,8 +58,8 @@ def load_table(tab_fp):
 
 def nobunaga(query: DNAFASTAFormat, reference_reads: DNAFASTAFormat,
              reference_taxonomy: pd.Series, database: Bowtie2IndexDirFmt,
-             taxacut: float=0.8,
-             threads: int=1, percent_id: float=0.98) -> biom.Table:
+             taxacut: float = 0.8,
+             threads: int = 1, percent_id: float = 0.98) -> biom.Table:
     with tempfile.TemporaryDirectory() as tmpdir:
         setup_database_dir(tmpdir,
                            database, reference_reads, reference_taxonomy)
@@ -83,8 +83,8 @@ def nobunaga(query: DNAFASTAFormat, reference_reads: DNAFASTAFormat,
 
 def minipipe(query: DNAFASTAFormat, reference_reads: DNAFASTAFormat,
              reference_taxonomy: pd.Series, database: Bowtie2IndexDirFmt,
-             taxacut: float=0.8,
-             threads: int=1, percent_id: float=0.98) -> (
+             taxacut: float = 0.8,
+             threads: int = 1, percent_id: float = 0.98) -> (
                      biom.Table, biom.Table, biom.Table, biom.Table):
     with tempfile.TemporaryDirectory() as tmpdir:
         # database_dir = tmpdir.name

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.

NOTE: Please exercise caution in reviewing, as I was unable to test changes. "make test" fails on my machine in a clean *master* branch of Shogun, as described below:

ImportError while importing test module '/home/chris/src/qiime2/q2-shogun/q2_shogun/tests/test_shogun.py'. 
Hint: make sure your test modules/packages have valid Python names.
Traceback:
q2_shogun/tests/test_shogun.py:14: in <module>   from qiime2.plugins import shogun
E   ImportError: cannot import name 'shogun'
