### PR TITLE
TEST: fixes failing test

### DIFF
--- a/q2_shogun/tests/test_shogun.py
+++ b/q2_shogun/tests/test_shogun.py
@@ -31,19 +31,27 @@ class TestShogun(TestPluginBase):
         self.query = _load('query.qza')
         self.refseqs = _load('refseqs.qza')
         self.taxonomy = _load('taxonomy.qza')
-        self.taxatable = _load('taxatable.qza').view(biom.Table)
-
-    # def test_minipipe(self):
-    #    taxa, kegg, modules, pathways = shogun.actions.minipipe(
-    #        query=self.query, reference_reads=self.refseqs,
-    #        reference_taxonomy=self.taxonomy, database=self.database)
+        self.taxatable = _load('taxatable.qza')
 
     def test_nobunaga(self):
         taxa = shogun.actions.nobunaga(
             query=self.query, reference_reads=self.refseqs,
             reference_taxonomy=self.taxonomy, database=self.database)
-        taxa_table = taxa.taxa_table.view(biom.Table).sort()
-        report = taxa_table.descriptive_equality(self.taxatable)
+        observed_taxa_table = taxa.taxa_table.view(biom.Table).\
+            sort(axis='observation').sort(axis='sample')
+
+        expected_taxa_table = self.taxatable.view(biom.Table).\
+            sort(axis='observation').sort(axis='sample')
+
+        observed_feature_ids = set(observed_taxa_table.ids(axis='observation'))
+        expected_feature_ids = set(expected_taxa_table.ids(axis='observation'))
+        self.assertEqual(observed_feature_ids, expected_feature_ids)
+
+        observed_sample_ids = set(observed_taxa_table.ids(axis='sample'))
+        expected_sample_ids = set(expected_taxa_table.ids(axis='sample'))
+        self.assertEqual(observed_sample_ids, expected_sample_ids)
+
+        report = observed_taxa_table.descriptive_equality(expected_taxa_table)
         self.assertIn('Tables appear equal', report, report)
 
 


### PR DESCRIPTION
The Travis build is currently failing because the sorting of the observation/feature ids differed in the two tables being compared. 

This PR fixes that and additionally adds specific tests of the id lists so that more descriptive output would be available in the event of a failure (I added these during debugging).

